### PR TITLE
NO-JIRA: Disable automatic go module updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "schedule": ["on Tuesday"]
+  "schedule": ["on Tuesday"],
+  "gomod": {
+    "enabled": false
+  }
 }


### PR DESCRIPTION
This PR disables the automatic go.mod updates. We manage this manually and this functionality creates a lot of noise.