### PR TITLE
NO-JIRA: Run make generate based on the main branch JobSet

### DIFF
--- a/bindata/assets/jobset-controller-generated/admissionregistration.k8s.io_v1_mutatingwebhookconfiguration_jobset-mutating-webhook-configuration.yaml
+++ b/bindata/assets/jobset-controller-generated/admissionregistration.k8s.io_v1_mutatingwebhookconfiguration_jobset-mutating-webhook-configuration.yaml
@@ -28,7 +28,6 @@ webhooks:
     - v1alpha2
     operations:
     - CREATE
-    - UPDATE
     resources:
     - jobsets
   sideEffects: None

--- a/bindata/assets/jobset-controller-generated/apps_v1_deployment_jobset-controller-manager.yaml
+++ b/bindata/assets/jobset-controller-generated/apps_v1_deployment_jobset-controller-manager.yaml
@@ -74,6 +74,8 @@ spec:
           readOnly: true
       securityContext:
         runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: jobset-controller-manager
       terminationGracePeriodSeconds: 10
       volumes:


### PR DESCRIPTION
We have updated operand code base with the latest changes in upstream by https://github.com/openshift/kubernetes-sigs-jobset/pull/61.

So this PR runs `make generate` to align. All tests must pass.