### PR TITLE
add useful renovate config to trigger auto merge of konflux

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,56 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "https://github.com/konflux-ci/mintmaker/blob/main/config/renovate/renovate.json?raw=true"
+  ],
+  "assigneesFromCodeOwners": true,
+  "automergeStrategy": "auto",
+  "automergeType": "pr",
+  "prConcurrentLimit": 5,
+  "ignoreTests": false,
+  "rebaseLabel": "needs-rebase",
+  "rebaseWhen": "behind-base-branch",
+  "recreateWhen": "always",
+  "commitMessageSuffix": "{{baseBranch}}",
   "schedule": ["on Tuesday"],
+  "tekton": {
+    "enabled": true,
+    "packageRules": [
+      {
+        "matchUpdateTypes": [
+          "minor",
+          "patch",
+          "pin",
+          "digest"
+        ],
+        "automerge": true,
+        "addLabels": [
+          "lgtm",
+          "approved"
+        ]
+      }
+    ]
+  },
+  "dockerfile": {
+    "enabled": true,
+    "packageRules": [
+      {
+        "matchFileNames": [
+          "Dockerfile*",
+          "*.Dockerfile"
+        ],
+        "automerge": true,
+        "addLabels": [
+          "lgtm",
+          "approved"
+        ]
+      }
+    ]
+  },
   "gomod": {
     "enabled": false
+  },
+  "vulnerabilityAlerts": {
+    "enabled": true
   }
 }


### PR DESCRIPTION
In kueue, we were drowning under all the konflux dependency updates we get.

We found this useful as it will auto merge konflux and docker updates as long as CI passes.

If this is of interest, I can open up a PR in openshift/release to trust konflux for this repo and this should work without issue.