### PR TITLE
fix typo for mirror sets

### DIFF
--- a/.tekton/images-mirror-set.yaml
+++ b/.tekton/images-mirror-set.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: operator.openshift.io/v1alpha1
+apiVersion: operator.openshift.io/v1
 kind: ImageDigestMirrorSet
 metadata:
   name: jobset-operator-mirror-set


### PR DESCRIPTION
As I testing with trainer team, they had problems applying this Image Mirror Set.

It looks like Image Mirror Sets went GA so we should use the v1 API and not v1alpha1 API