### PR TITLE
NO-JIRA: add v4.21 to jobset

### DIFF
--- a/generate-fbc.sh
+++ b/generate-fbc.sh
@@ -1,4 +1,4 @@
-for OCP_VERSION in v4.18 v4.19 v4.20; do
+for OCP_VERSION in v4.18 v4.19 v4.20 v4.21; do
     echo "OCP_VERSION: ${OCP_VERSION}"
     opm alpha render-template semver $OCP_VERSION/catalog-template.yaml --migrate-level=bundle-object-to-csv-metadata > $OCP_VERSION/catalog/jobset-operator/catalog.json;
 done

--- a/v4.21/Containerfile.catalog
+++ b/v4.21/Containerfile.catalog
@@ -1,0 +1,21 @@
+# The base image is expected to contain /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.21
+
+ENTRYPOINT ["/bin/opm"]
+CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]
+
+COPY catalog/ /configs
+
+RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
+
+# Core bundle labels.
+
+LABEL operators.operatorframework.io.index.configs.v1=/configs
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=job-set
+LABEL operators.operatorframework.io.bundle.channels.v1=tech-preview
+LABEL operators.operatorframework.io.bundle.channel.default.v1=tech-preview
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.34.2
+LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1

--- a/v4.21/catalog-template.yaml
+++ b/v4.21/catalog-template.yaml
@@ -1,0 +1,7 @@
+Schema: olm.semver
+GenerateMajorChannels: false
+GenerateMinorChannels: true
+DefaultChannelTypePreference: "minor"
+Stable:
+  Bundles:
+    - Image: registry.redhat.io/job-set/jobset-operator-bundle@sha256:1f8fd0e1c6636b04dcc7cf4cf27d33edd70c31db5b6c5fc305e415df8a5b10d5

--- a/v4.21/catalog/jobset-operator/catalog.json
+++ b/v4.21/catalog/jobset-operator/catalog.json
@@ -1,0 +1,143 @@
+{
+    "schema": "olm.package",
+    "name": "job-set",
+    "defaultChannel": "tech-preview-v0.1"
+}
+{
+    "schema": "olm.channel",
+    "name": "tech-preview-v0.1",
+    "package": "job-set",
+    "entries": [
+        {
+            "name": "jobset-operator.v0.1.0"
+        }
+    ]
+}
+{
+    "schema": "olm.bundle",
+    "name": "jobset-operator.v0.1.0",
+    "package": "job-set",
+    "image": "registry.redhat.io/job-set/jobset-operator-bundle@sha256:1f8fd0e1c6636b04dcc7cf4cf27d33edd70c31db5b6c5fc305e415df8a5b10d5",
+    "properties": [
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "operator.openshift.io",
+                "kind": "JobSetOperator",
+                "version": "v1"
+            }
+        },
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "job-set",
+                "version": "0.1.0"
+            }
+        },
+        {
+            "type": "olm.csv.metadata",
+            "value": {
+                "annotations": {
+                    "alm-examples": "[\n  {\n    \"apiVersion\": \"operator.openshift.io/v1\",\n    \"kind\": \"JobSetOperator\",\n    \"metadata\": {\n      \"name\": \"cluster\",\n      \"namespace\": \"openshift-jobset-operator\"\n    },\n    \"spec\": {\n      \"managementState\": \"Managed\",\n    }\n  }\n]\n",
+                    "capabilities": "Basic Install",
+                    "categories": "OpenShift Optional",
+                    "console.openshift.io/operator-monitoring-default": "true",
+                    "createdAt": "2025-08-26",
+                    "description": "The JobSet Operator provides the ability to deploy a JobSet controller in OpenShift.\n",
+                    "features.operators.openshift.io/cnf": "false",
+                    "features.operators.openshift.io/cni": "false",
+                    "features.operators.openshift.io/csi": "false",
+                    "features.operators.openshift.io/disconnected": "true",
+                    "features.operators.openshift.io/fips-compliant": "true",
+                    "features.operators.openshift.io/proxy-aware": "false",
+                    "features.operators.openshift.io/tls-profiles": "false",
+                    "features.operators.openshift.io/token-auth-aws": "false",
+                    "features.operators.openshift.io/token-auth-azure": "false",
+                    "features.operators.openshift.io/token-auth-gcp": "false",
+                    "operatorframework.io/cluster-monitoring": "true",
+                    "operatorframework.io/suggested-namespace": "openshift-jobset-operator",
+                    "operators.openshift.io/valid-subscription": "[\"OpenShift Container Platform\", \"OpenShift Platform Plus\"]",
+                    "operators.operatorframework.io/builder": "operator-sdk-v1.34.2",
+                    "repository": "https://github.com/openshift/jobset-operator",
+                    "support": "Red Hat, Inc."
+                },
+                "apiServiceDefinitions": {},
+                "crdDescriptions": {
+                    "owned": [
+                        {
+                            "name": "jobsetoperators.operator.openshift.io",
+                            "version": "v1",
+                            "kind": "JobSetOperator",
+                            "displayName": "Job Set Operator"
+                        }
+                    ]
+                },
+                "description": "The JobSet Operator provides the ability to deploy a JobSet controller in OpenShift.\n",
+                "displayName": "Job Set Operator",
+                "installModes": [
+                    {
+                        "type": "OwnNamespace",
+                        "supported": true
+                    },
+                    {
+                        "type": "SingleNamespace",
+                        "supported": true
+                    },
+                    {
+                        "type": "MultiNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "AllNamespaces",
+                        "supported": false
+                    }
+                ],
+                "keywords": [
+                    "jobset-operator",
+                    "jobset"
+                ],
+                "labels": {
+                    "operatorframework.io/arch.amd64": "supported",
+                    "operatorframework.io/arch.arm64": "supported",
+                    "operatorframework.io/arch.ppc64le": "supported",
+                    "operatorframework.io/arch.s390x": "supported"
+                },
+                "links": [
+                    {
+                        "name": "Source Code",
+                        "url": "https://github.com/openshift/kubernetes-sigs-jobset"
+                    },
+                    {
+                        "name": "Source Code",
+                        "url": "https://github.com/openshift/jobset-operator"
+                    }
+                ],
+                "maintainers": [
+                    {
+                        "name": "Red Hat",
+                        "email": "support@redhat.com"
+                    }
+                ],
+                "maturity": "alpha",
+                "minKubeVersion": "1.31.0",
+                "provider": {
+                    "name": "Red Hat, Inc."
+                }
+            }
+        }
+    ],
+    "relatedImages": [
+        {
+            "name": "",
+            "image": "registry.redhat.io/job-set/jobset-operator-bundle@sha256:1f8fd0e1c6636b04dcc7cf4cf27d33edd70c31db5b6c5fc305e415df8a5b10d5"
+        },
+        {
+            "name": "jobset-operator",
+            "image": "registry.redhat.io/job-set/jobset-rhel9-operator@sha256:e5b874a603a2f6cb97b4312ea2b00275cc4304773bcd9fca0782f1335576cd0b"
+        },
+        {
+            "name": "jobset",
+            "image": "registry.redhat.io/job-set/jobset-rhel9@sha256:104e8a00fea252ffeb7fbef678be0b2f57c6e0cdde8dcae0134c2a4d681cb63b"
+        }
+    ]
+}


### PR DESCRIPTION
For kueue, I was getting our CI ready to start testing on 4.21.

I hit an issue where JobSetOperator 0.1 was not found in 4.21 catalog.

https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/71672/rehearse-71672-pull-ci-openshift-kueue-operator-release-1.2-test-e2e-4-21/1991953101946359808

Opening this up to see if we could add this to 4.21.