### PR TITLE
CNTRLPLANE-3868: Add NetworkPolicy RBAC to jobset CSV

### DIFF
--- a/deploy/04_role.yaml
+++ b/deploy/04_role.yaml
@@ -100,3 +100,15 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch

--- a/manifests/jobset-operator.clusterserviceversion.yaml
+++ b/manifests/jobset-operator.clusterserviceversion.yaml
@@ -391,6 +391,18 @@ spec:
                 - update
                 - watch
             - apiGroups:
+                - networking.k8s.io
+              resources:
+                - networkpolicies
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
                 - ""
               resources:
                 - configmaps


### PR DESCRIPTION
https://redhat.atlassian.net/browse/CNTRLPLANE-3635 
Create the necessary rbac for our olm based operator jobset for the control plane:

Please find the below warnings without the fix:
```  warnings:
  - metadata:
      code: olm.required_network_policy_rbac_for_operands
      collections:
      - redhat
      - redhat_security
      description: Operators are required to manage the network policies of their
        operands. This rule verifies that operator bundles request sufficient RBAC
        permissions to manage NetworkPolicy lifecycle (create, delete, and update/patch)
        for networking.k8s.io/networkpolicies in their ClusterServiceVersion. Bundles
        whose operator name and major.minor version are listed in the `operator_network_policy_rbac_exceptions`
        rule data key are exempt from this requirement.
      effective_on: "2026-08-07T00:00:00Z"
      solution: Add a rule granting create, delete, and update/patch on networking.k8s.io/networkpolicies
        to the ClusterServiceVersion clusterPermissions or permissions, or add the
        operator name and its major.minor version to the operator_network_policy_rbac_exceptions
        rule data key.
      title: NetworkPolicy RBAC present in OLM bundle
    msg: Operator "job-set" version "1.0.0" is missing required NetworkPolicy RBAC
      (networking.k8s.io/networkpolicies with create, delete, and update/patch)

```
With the fix:
```
  successes:
  - metadata:
      code: olm.required_network_policy_rbac_for_operands
      collections:
      - redhat
      - redhat_security
      description: Operators are required to manage the network policies of their
        operands. This rule verifies that operator bundles request sufficient RBAC
        permissions to manage NetworkPolicy lifecycle (create, delete, and update/patch)
        for networking.k8s.io/networkpolicies in their ClusterServiceVersion. Bundles
        whose operator name and major.minor version are listed in the `operator_network_policy_rbac_exceptions`
        rule data key are exempt from this requirement.
      effective_on: "2026-08-07T00:00:00Z"
      title: NetworkPolicy RBAC present in OLM bundle
    msg: Pass
  violations: []
  warnings: []

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded the operator’s ability to manage Kubernetes NetworkPolicies, including create, get, list, watch, patch, update, and delete operations.
* **Security & Permissions**
  * Updated RBAC so the operator can reconcile NetworkPolicies end-to-end, enabling automated application and removal of network policy rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->