### PR TITLE
NO-JIRA: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The JobSet Operator provides the ability to deploy a
 | jobset operator version | jobset version | ocp version | k8s version | golang |
 |-------------------------|----------------|-------------|-------------|--------|
 | 0.1.0                   | 0.9.1          | 4.18-4.20   | 1.33        | 1.24   |
-| 1.0.0                   | 0.11.0         | 4.18-4.20   | 1.35        | 1.25   |
+| 1.0.0                   | 0.11.0         | 4.18-5.0    | 1.35        | 1.25   |
 
 ## Deploy the Operator
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the compatibility table to indicate that JobSet Operator 1.0.0 supports OpenShift Container Platform versions 4.18 through 5.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->